### PR TITLE
Support react-native >=0.47.0

### DIFF
--- a/android/src/main/java/com/reactlibrary/androidsettings/RNANAndroidSettingsLibraryPackage.java
+++ b/android/src/main/java/com/reactlibrary/androidsettings/RNANAndroidSettingsLibraryPackage.java
@@ -17,11 +17,6 @@ public class RNANAndroidSettingsLibraryPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
       return Collections.emptyList();
     }

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
     "react-native"
   ],
   "author": "Aleksandern",
-  "license": "ISC"
+  "license": "ISC",
+  "peerDependencies": {
+    "react-native": ">=0.47.0"
+  }
 }


### PR DESCRIPTION
* **Problem:** React-native made a breaking change to the ReactPackage (see facebook/react-native@ce6fb337a146e6f261f2afb564aa19363774a7a8). It no longer has a `createJSModules` method:

  https://github.com/facebook/react-native/blob/d42697bcf3c9ad4e51c4ef57f01bf4710decf30b/ReactAndroid/src/main/java/com/facebook/react/ReactPackage.java#L31-L43

  react-native-android-settings-library fails to compile because [it still has the `createJSModules` method defined](https://github.com/Aleksandern/react-native-android-settings-library/blob/2566f9726cb6069d4c628a1ba393f6c6e6cae97e/android/src/main/java/com/reactlibrary/androidsettings/RNANAndroidSettingsLibraryPackage.java#L19-L22)
* **Solution:** Remove the `createJSModules` from `RNANAndroidSettingsLibraryPackage`.
* **Testing:** ???