### PR TITLE
support apps using react native >= 0.47 [backward compatible with earlier ver]

### DIFF
--- a/android/src/main/java/com/reactlibrary/androidsettings/RNANAndroidSettingsLibraryPackage.java
+++ b/android/src/main/java/com/reactlibrary/androidsettings/RNANAndroidSettingsLibraryPackage.java
@@ -16,7 +16,11 @@ public class RNANAndroidSettingsLibraryPackage implements ReactPackage {
       return Arrays.<NativeModule>asList(new RNANAndroidSettingsLibraryModule(reactContext));
     }
 
-    @Override
+    // Do not annotate the method with @Override
+    // This will provide backward compatibility for apps using react-native version < 0.47
+    // Breaking change in react-native version 0.47 : Android Remove unused createJSModules calls
+    // Find more information here : https://github.com/facebook/react-native/releases/tag/v0.47.2
+    // https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }


### PR DESCRIPTION
Problem : Package is not compatible with react native version above `0.47`

Solution : Do not annotate createJSModules() with @Override . This will provide backward and forward compatibility

Please note if you agree with the fix , it would need publishing a new version of the package. Would appreciate your prompt reply. @iancanderson @Aleksandern 